### PR TITLE
fixes and tests annotating kinds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: kindly-advice CI
+
+on: [push]
+
+jobs:
+
+  clojure:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      - name: Install Clojure tools
+        uses: DeLaGuardo/setup-clojure@11.0
+        with:
+          cli: latest              # Clojure CLI based on tools.deps
+
+      # Optional step:
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          # List all files containing dependencies:
+          key: cljdeps-${{ hashFiles('deps.edn') }}
+          restore-keys: cljdeps-
+
+      - name: Execute tests
+        run: clojure -M:test -m cognitect.test-runner
+
+# TODO: for this to work: change myusername to a valid Clojars username, generate a token, add it as a secret in github project settings
+#      - name: Deploy
+#        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'org.scicloj/kindly-advice'
+#        env:
+#          CLOJARS_PASSWORD: ${{ secrets.CLOJARSTOKEN }}
+#          CLOJARS_USERNAME: myusername
+#        run: clojure -T:build jar && clojure -T:build deploy

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,12 @@
-{:deps {org.clojure/clojure         {:mvn/version "1.10.3"}
-        org.scicloj/kindly {:mvn/version "4-alpha3"}}
- :aliases {:dev {:extra-deps {org.scicloj/clay {:mvn/version "2-alpha32"}
-                              scicloj/tablecloth {:mvn/version "7.000-beta-51"}}
-                 :extra-paths ["notebooks"]}
-           :build {:deps {io.github.seancorfield/build-clj
-                          {:git/tag "v0.6.4" :git/sha "c21cfde"}}
+{:deps    {org.clojure/clojure {:mvn/version "1.11.1"}}
+ :aliases {:dev   {:extra-deps  {org.scicloj/clay   {:mvn/version "2-alpha32"}
+                                 scicloj/tablecloth {:mvn/version "7.000-beta-51"}}
+                   :extra-paths ["test" "notebooks"]}
+           ;; Run tests with `clojure -T:build`
+           :build {:deps       {io.github.seancorfield/build-clj
+                                {:git/tag "v0.6.4" :git/sha "c21cfde"}}
                    :ns-default build}
-           :test {:extra-paths ["test"]
-                  :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
-                               io.github.cognitect-labs/test-runner
-                               {:git/tag "v0.5.0" :git/sha "48c3c67"}
-                               org.scicloj/clay {:mvn/version "2-alpha32"}}}}}
+           ;; Run tests with `clojure -M:test -m cognitect.test-runner`
+           :test  {:extra-paths ["test"]
+                   :extra-deps  {org.scicloj/kindly                   {:mvn/version "4-alpha7"}
+                                 io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "48c3c67"}}}}}

--- a/src/scicloj/kindly_advice/v1/completion.cljc
+++ b/src/scicloj/kindly_advice/v1/completion.cljc
@@ -29,18 +29,20 @@
                           (keyword)))))
 
 (defn meta-kind [x]
-  (when-let [m (meta x)]
-    (or
-      ;; ^{:kindly/kind :kind/table} x
-      (kind (:kindly/kind m))
+  (or
+    (when-let [m (meta x)]
+      (or
+        ;; ^{:kindly/kind :kind/table} x
+        (kind (:kindly/kind m))
 
-      ;; ^kind/table x
-      (kind (:tag m))
+        ;; ^kind/table x
+        (kind (:tag m))
 
-      ;; ^:kind/table x
-      (->> (keys m)
-           (keep kind)
-           (first)))))
+        ;; ^:kind/table x
+        (->> (keys m)
+             (keep kind)
+             (first))))
+    (when (var? x) (meta-kind @x))))
 
 (defn complete-meta-kind [{:keys [form value]
                            :as context}]

--- a/src/scicloj/kindly_advice/v1/completion.cljc
+++ b/src/scicloj/kindly_advice/v1/completion.cljc
@@ -1,4 +1,5 @@
-(ns scicloj.kindly-advice.v1.completion)
+(ns scicloj.kindly-advice.v1.completion
+  (:require [clojure.string :as str]))
 
 (defn eval-in-ns [ns form]
   (if ns
@@ -16,31 +17,36 @@
       (throw (ex-info "context missing both form and value"
                       {:context context})))))
 
-(defn form-meta-kind [form]
-  (when-let [m (some-> form meta)]
-    (or (some->> m
-                 :tag
-                 resolve
-                 deref
-                 namespace
-                 (= "kind"))
-        (some->> m
-                 keys
-                 (filter #(-> %
-                              namespace
-                              (= "kind")))
-                 first))))
+(defn kind [x]
+  (cond (keyword? x) (when (= (namespace x) "kind")
+                       x)
+        (symbol? x) (when (= (namespace x) "kind")
+                      (keyword x))
+        (fn? x) (let [tag-str (str x)]
+                  (some-> (re-find #".*\.(kind\$.*)@.*" tag-str)
+                          (second)
+                          (str/replace \$ \/)
+                          (keyword)))))
 
-(defn value-meta-kind [value]
-  (-> value
-      meta
-      :kindly/kind))
+(defn meta-kind [x]
+  (when-let [m (meta x)]
+    (or
+      ;; ^{:kindly/kind :kind/table} x
+      (kind (:kindly/kind m))
+
+      ;; ^kind/table x
+      (kind (:tag m))
+
+      ;; ^:kind/table x
+      (->> (keys m)
+           (keep kind)
+           (first)))))
 
 (defn complete-meta-kind [{:keys [form value]
                            :as context}]
   (assoc context
-         :meta-kind (or (form-meta-kind form)
-                        (value-meta-kind value))))
+         :meta-kind (or (meta-kind form)
+                        (meta-kind value))))
 
 (defn complete [context]
   (-> context

--- a/test/scicloj/kindly_advice/v1/completion_test.cljc
+++ b/test/scicloj/kindly_advice/v1/completion_test.cljc
@@ -3,6 +3,13 @@
             [scicloj.kindly.v4.kind :as kind]
             [scicloj.kindly-advice.v1.completion :as kac]))
 
+(def table3 (kind/table {}))
+
+(def ^{:kindly/kind :kind/table} table4 {})
+
+(def ^:kind/table table5 {})
+
+
 (deftest meta-kind-test
   (testing "valid ways to annotate a kind"
     (is (= :kind/table (kac/meta-kind (kind/table {}))))
@@ -18,4 +25,9 @@
     (is (= nil (kac/meta-kind ^:kindly/table {})))
     (is (= nil (kac/kind 1)))
     (is (= nil (kac/meta-kind ^{:kindly/kind 1} {})))
-    (is (= nil (kac/meta-kind ^{:kindly/kind :not-a-kind} {})))))
+    (is (= nil (kac/meta-kind ^{:kindly/kind :not-a-kind} {}))))
+  (testing "tricky kinds"
+    (is (= :kind/table (kac/meta-kind table3)))
+    (is (= :kind/table (kac/meta-kind #'table3)))
+    (is (= :kind/table (kac/meta-kind #'table4)))
+    (is (= :kind/table (kac/meta-kind #'table5)))))

--- a/test/scicloj/kindly_advice/v1/completion_test.cljc
+++ b/test/scicloj/kindly_advice/v1/completion_test.cljc
@@ -1,0 +1,21 @@
+(ns scicloj.kindly-advice.v1.completion-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [scicloj.kindly.v4.kind :as kind]
+            [scicloj.kindly-advice.v1.completion :as kac]))
+
+(deftest meta-kind-test
+  (testing "valid ways to annotate a kind"
+    (is (= :kind/table (kac/meta-kind (kind/table {}))))
+    (is (= :kind/table (kac/meta-kind ^{:kindly/kind :kind/table} {})))
+    (is (= :kind/table (kac/meta-kind ^{:kindly/kind kind/table} {})))
+    (is (= :kind/table (kac/meta-kind ^{:kindly/kind 'kind/table} {})))
+    (is (= :kind/table (kac/meta-kind ^{kind/table true} {})))
+    (is (= :kind/table (kac/meta-kind ^{'kind/table true} {})))
+    (is (= :kind/table (kac/meta-kind ^:kind/table {})))
+    (is (= :kind/table (kac/meta-kind ^kind/table {}))))
+  (testing "invalid kinds"
+    (is (= nil (kac/kind :kindly/table)))
+    (is (= nil (kac/meta-kind ^:kindly/table {})))
+    (is (= nil (kac/kind 1)))
+    (is (= nil (kac/meta-kind ^{:kindly/kind 1} {})))
+    (is (= nil (kac/meta-kind ^{:kindly/kind :not-a-kind} {})))))


### PR DESCRIPTION
The previous implementation was not detecting cases like ^:kind/table {...}
These changes allow pretty much any comprehensible style to be detected,
and additionally disallows arbitrary kinds (all kinds must be keywords in the kind namespace).