### PR TITLE
Update kindly dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps    {org.clojure/clojure {:mvn/version "1.11.1"}
-           org.scicloj/kindly  {:mvn/version "4-beta11"}}
+           org.scicloj/kindly  {:mvn/version "4-beta12"}}
  :aliases {:dev   {:extra-deps  {org.scicloj/clay   {:mvn/version "2-alpha87"}
                                  scicloj/tablecloth {:mvn/version "7.021"}}
                    :extra-paths ["test" "notebooks"]}


### PR DESCRIPTION
I am using `kindly-render`. The `scicloj.kindly-render.note.to-hiccup-js/render` function fails with the current Kindly dependency, but succeeds with the `4-beta12` version.  I have not done any detailed testing, but the tests pass with the newer version and it seems to fix the issue.
