### PR TITLE
Temporarily adds v2-namespaces, using kindly with side-effect free options

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
-{:deps    {org.clojure/clojure {:mvn/version "1.11.1"}
-           org.scicloj/kindly  {:mvn/version "4-beta16"}}
+{:deps    {org.clojure/clojure {:mvn/version "1.12.4"}
+           org.scicloj/kindly  {:local/root "../kindly"}}
  :aliases {:dev   {:extra-deps  {org.scicloj/clay   {:mvn/version "2-beta19"}
                                  scicloj/tablecloth {:mvn/version "7.029.2"}}
                    :extra-paths ["test" "notebooks"]}

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps    {org.clojure/clojure {:mvn/version "1.12.4"}
-           org.scicloj/kindly  {:git/sha "2863a8e08c39b1ec50a2ffde2d0874942a113d4b"}}
+           io.github.scicloj/kindly {:git/sha "2863a8e08c39b1ec50a2ffde2d0874942a113d4b"}}
  :aliases {:dev   {:extra-deps  {org.scicloj/clay   {:mvn/version "2-beta19"}
                                  scicloj/tablecloth {:mvn/version "7.029.2"}}
                    :extra-paths ["test" "notebooks"]}

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps    {org.clojure/clojure {:mvn/version "1.12.4"}
-           org.scicloj/kindly  {:local/root "../kindly"}}
+           org.scicloj/kindly  {:git/sha "2863a8e08c39b1ec50a2ffde2d0874942a113d4b"}}
  :aliases {:dev   {:extra-deps  {org.scicloj/clay   {:mvn/version "2-beta19"}
                                  scicloj/tablecloth {:mvn/version "7.029.2"}}
                    :extra-paths ["test" "notebooks"]}

--- a/src/scicloj/kindly_advice/v2/advisors.cljc
+++ b/src/scicloj/kindly_advice/v2/advisors.cljc
@@ -1,0 +1,73 @@
+(ns scicloj.kindly-advice.v2.advisors)
+
+(defn advice->recommended-kind [advice]
+  (-> advice
+      first
+      first))
+
+(defn update-context [context advisor]
+  (if-let [advice (advisor context)]
+    (-> context
+        (update :kind
+                (fn [kind]
+                  (or kind
+                      (advice->recommended-kind advice))))
+        (update :advice
+                concat advice))
+    context))
+
+(defn meta-kind-advisor [{:keys [meta-kind]
+                          :as context}]
+  (when meta-kind
+    [[meta-kind {:reason :metadata}]]))
+
+(defn predicate-based-advisor [{:keys [predicate-kinds]}]
+  (fn [{:keys [value]
+        :as context}]
+    (->> predicate-kinds
+         (map (fn [[predicate kind]]
+                (when (predicate value)
+                  [kind {:reason :predicate}])))
+         (remove nil?)
+         seq)))
+
+(def default-predicate-kinds-v2
+  [[(fn [v]
+      (-> v
+          type
+          pr-str
+          (= "smile.regression.LinearModel")))
+    :kind/smile-model]
+   [(fn [v]
+      (-> v
+          type
+          pr-str
+          (= "tech.v3.dataset.impl.dataset.Dataset")))
+    :kind/dataset]
+   [(fn [v]
+      (-> v
+          type
+          pr-str
+          (= "java.awt.image.BufferedImage")))
+    :kind/image]
+   [(fn [v] (let [m (meta v)]
+              (and (:portal.viewer/reagent? m)
+                   (-> m :portal.viewer/default keyword?)
+                   (-> m :portal.viewer/default namespace (= "emmy.portal")))))
+    :kind/emmy-viewers]
+   [(fn [v]
+      (some-> v
+              meta
+              :test
+              fn?))
+    :kind/test]
+   [var? :kind/var]
+   [map? :kind/map]
+   [set? :kind/set]
+   [vector? :kind/vector]
+   [sequential? :kind/seq]])
+
+(def default-advisors
+  [meta-kind-advisor
+   (predicate-based-advisor
+    {:predicate-kinds default-predicate-kinds-v2})])

--- a/src/scicloj/kindly_advice/v2/api.cljc
+++ b/src/scicloj/kindly_advice/v2/api.cljc
@@ -1,0 +1,30 @@
+(ns scicloj.kindly-advice.v2.api
+  (:require [scicloj.kindly-advice.v2.advisors :as advisors]
+            [scicloj.kindly-advice.v2.completion :as completion]))
+
+(def default-advisors
+  advisors/default-advisors)
+
+(def *advisors
+  (atom default-advisors))
+
+(defn advise
+  "Adds advice to a context such as `{:form [:div]}`.
+  Advice recommends a kind `{:form [:div], :value [:div], :kind :kindly/hiccup}`.
+  Works best with both form and value because metadata may appear on either.
+  If no value is present, will evaluate `:form` and populate `:value` and `:kind`."
+  ([context]
+   (advise context @*advisors))
+  ([context advisors]
+   (-> context
+       completion/complete
+       (#(reduce advisors/update-context
+                 %
+                 advisors))
+       (update :advice vec))))
+
+(defn add-advisor! [advisor]
+  (swap! *advisors (partial cons advisor)))
+
+(defn set-advisors! [advisors]
+  (reset! *advisors advisors))

--- a/src/scicloj/kindly_advice/v2/completion.cljc
+++ b/src/scicloj/kindly_advice/v2/completion.cljc
@@ -1,0 +1,134 @@
+(ns scicloj.kindly-advice.v2.completion
+  (:require [clojure.string :as str]
+            [scicloj.kindly.v5.api :as kindly]))
+
+(defn eval-in-ns [ns form]
+  (if ns
+    (binding [*ns* ns]
+      (eval form))
+    (eval form)))
+
+(defn complete-value [{:keys [ns form]
+                       :as   context}]
+  (if (contains? context :value)
+    context
+    (if (contains? context :form)
+      (assoc context
+        :value (eval-in-ns ns form))
+      (throw (ex-info "context missing both form and value"
+                      {:context context})))))
+
+(defn kind [x]
+  (cond (keyword? x) (when (= (namespace x) "kind")
+                       x)
+        (symbol? x) (when (= (namespace x) "kind")
+                      (keyword x))
+        (fn? x) (let [tag-str (str x)]
+                  (some-> (re-find #".*\.(kind\$.*)@.*" tag-str)
+                          (second)
+                          (str/replace \$ \/)
+                          (keyword)))))
+
+(defn meta-kind [x]
+  (or
+    (when-let [m (meta x)]
+      (or
+        ;; ^{:kindly/kind :kind/table} x
+        (kind (:kindly/kind m))
+
+        ;; ^kind/table x
+        (kind (:tag m))
+
+        ;; ^:kind/table x
+        (->> (keys m)
+             (keep kind)
+             (first))))
+    (when (var? x) (meta-kind @x))))
+
+(defn complete-meta-kind [{:keys [form value]
+                           :as   context}]
+  (assoc context
+    :meta-kind (or (meta-kind form)
+                   (meta-kind value))))
+
+(defn hide-code? [{:as note :keys [code form value kind]} options]
+  (let [m (merge options (meta form) (meta value))
+        hide-code (select-keys m [:hide-code
+                                  :kind/hide-code
+                                  :kindly/hide-code
+                                  :kindly/hide-code?])]
+    (or (= kind :kind/hidden)
+        (nil? code)
+        (some val hide-code)
+        (and kind
+             (empty? hide-code)
+             (some-> options :kinds-that-hide-code kind)))))
+
+(def default-hide-value-syms
+  '#{ns comment
+     def defonce defn defn- defmacro
+     defrecord defprotocol deftype
+     extend-protocol extend
+     require})
+
+(defn hide-value? [{:as note :keys [form value kind]}
+                   {:as options :keys [hide-nils hide-vars hide-value-syms]}]
+  (let [m (merge options (meta form) (meta value))
+        hide-value (select-keys m [:hide-value
+                                   :kind/hide-value
+                                   :kindly/hide-value
+                                   :kindly/hide-value?])]
+    (or (= kind :kind/hidden)
+        (some val hide-value)
+        (and hide-nils (nil? value))
+        (and hide-vars (var? value))
+        (and (sequential? form)
+             (some->> form first (get (or hide-value-syms default-hide-value-syms))))
+        (and kind
+             (empty? hide-value)
+             (some-> options :kinds-that-hide-values kind)))))
+
+(defn with-hide-options [context options]
+  (cond-> options
+          (hide-code? context options) (assoc :hide-code true)
+          (hide-value? context options) (assoc :hide-value true)))
+
+(defn meta-options [x]
+  (or
+   (when-let [m (meta x)]
+     (when (map? m)
+       (:kindly/options m)))
+   (when (var? x) (meta-options @x))))
+
+(defn complete-options [{:keys [form value]
+                         :as   context}]
+  (let [form-options (meta-options form)]
+    ;; Kindly options found on ns form cause options to be mutated,
+    ;; note that options on the value are already on the ns.
+
+    ;; TODO Instead this should be picked up in read-kinds.notes/merge-options
+
+    ;; TODO It also raises the question, maybe all option
+    ;; extraction/propagation related code should be here and in
+    ;; kindly, then used from read-kinds to get options for
+    ;; propagation
+    #_(when (and (sequential? form)
+               (-> form first (= 'ns))
+               form-options)
+      (kindly/merge-options! form-options))
+
+    (update context :kindly/options
+            (fn [context-options]
+              ;; context options come from configuration
+              (->> (kindly/deep-merge context-options
+                                      ;; options from the ns
+                                      ;; (kindly/get-options)
+                                      form-options
+                                      (meta-options value))
+                   (with-hide-options context))))))
+
+(defn complete [context]
+  (-> context
+      complete-value
+      complete-meta-kind
+      complete-options))


### PR DESCRIPTION
This temporarily adds v2-namespaces, using kindly with side-effect free merge options just to test current Clay and Clay with read-kinds in the same process.